### PR TITLE
Android Gradle 1.1.0

### DIFF
--- a/android-api-16/build.gradle
+++ b/android-api-16/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     dependencies {
         repositories {
+            maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
             mavenLocal()
             mavenCentral()
         }
@@ -11,7 +12,7 @@ buildscript {
 }
 
 apply plugin: "com.android.application"
-apply plugin: "robolectric"
+apply plugin: "org.robolectric"
 
 android {
     compileSdkVersion 16

--- a/android-api-16/build.gradle
+++ b/android-api-16/build.gradle
@@ -5,7 +5,7 @@ buildscript {
             mavenCentral()
         }
 
-        classpath "com.android.tools.build:gradle:1.1.0-rc1"
+        classpath "com.android.tools.build:gradle:1.1.0"
         classpath "org.robolectric:robolectric-gradle-plugin:1.0.0-SNAPSHOT"
     }
 }

--- a/android-api-16/build.gradle
+++ b/android-api-16/build.gradle
@@ -1,15 +1,17 @@
 buildscript {
     dependencies {
         repositories {
+            mavenLocal()
             mavenCentral()
         }
 
-        classpath "com.android.tools.build:gradle:1.0.0"
-        classpath "com.github.jcandksolutions.gradle:android-unit-test:2.1.1"
+        classpath "com.android.tools.build:gradle:1.1.0-rc1"
+        classpath "org.robolectric:robolectric-gradle-plugin:1.0.0-SNAPSHOT"
     }
 }
 
 apply plugin: "com.android.application"
+apply plugin: "robolectric"
 
 android {
     compileSdkVersion 16
@@ -25,9 +27,8 @@ android {
     }
 }
 
-apply plugin: "android-unit-test"
-
 dependencies {
     testCompile "junit:junit:4.10"
+    testCompile "org.assertj:assertj-core:1.7.0"
     testCompile "org.robolectric:robolectric:3.0-SNAPSHOT"
 }

--- a/android-api-19/build.gradle
+++ b/android-api-19/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     dependencies {
         repositories {
+            maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
             mavenLocal()
             mavenCentral()
         }
@@ -11,7 +12,7 @@ buildscript {
 }
 
 apply plugin: "com.android.application"
-apply plugin: "robolectric"
+apply plugin: "org.robolectric"
 
 android {
     compileSdkVersion 19

--- a/android-api-19/build.gradle
+++ b/android-api-19/build.gradle
@@ -1,15 +1,17 @@
 buildscript {
     dependencies {
         repositories {
+            mavenLocal()
             mavenCentral()
         }
 
-        classpath "com.android.tools.build:gradle:1.0.0"
-        classpath "com.github.jcandksolutions.gradle:android-unit-test:2.1.1"
+        classpath "com.android.tools.build:gradle:1.1.0-rc1"
+        classpath "org.robolectric:robolectric-gradle-plugin:1.0.0-SNAPSHOT"
     }
 }
 
 apply plugin: "com.android.application"
+apply plugin: "robolectric"
 
 android {
     compileSdkVersion 19
@@ -25,9 +27,8 @@ android {
     }
 }
 
-apply plugin: "android-unit-test"
-
 dependencies {
     testCompile "junit:junit:4.10"
+    testCompile "org.assertj:assertj-core:1.7.0"
     testCompile "org.robolectric:robolectric:3.0-SNAPSHOT"
 }

--- a/android-api-19/build.gradle
+++ b/android-api-19/build.gradle
@@ -5,7 +5,7 @@ buildscript {
             mavenCentral()
         }
 
-        classpath "com.android.tools.build:gradle:1.1.0-rc1"
+        classpath "com.android.tools.build:gradle:1.1.0"
         classpath "org.robolectric:robolectric-gradle-plugin:1.0.0-SNAPSHOT"
     }
 }

--- a/android-api-21/build.gradle
+++ b/android-api-21/build.gradle
@@ -1,15 +1,17 @@
 buildscript {
     dependencies {
         repositories {
+            mavenLocal()
             mavenCentral()
         }
 
-        classpath "com.android.tools.build:gradle:1.0.0"
-        classpath "com.github.jcandksolutions.gradle:android-unit-test:2.1.1"
+        classpath "com.android.tools.build:gradle:1.1.0-rc1"
+        classpath "org.robolectric:robolectric-gradle-plugin:1.0.0-SNAPSHOT"
     }
 }
 
 apply plugin: "com.android.application"
+apply plugin: "robolectric"
 
 android {
     compileSdkVersion 21
@@ -24,8 +26,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_7
     }
 }
-
-apply plugin: "android-unit-test"
 
 dependencies {
     testCompile "junit:junit:4.10"

--- a/android-api-21/build.gradle
+++ b/android-api-21/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     dependencies {
         repositories {
+            maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
             mavenLocal()
             mavenCentral()
         }
@@ -11,7 +12,7 @@ buildscript {
 }
 
 apply plugin: "com.android.application"
-apply plugin: "robolectric"
+apply plugin: "org.robolectric"
 
 android {
     compileSdkVersion 21

--- a/android-api-21/build.gradle
+++ b/android-api-21/build.gradle
@@ -5,7 +5,7 @@ buildscript {
             mavenCentral()
         }
 
-        classpath "com.android.tools.build:gradle:1.1.0-rc1"
+        classpath "com.android.tools.build:gradle:1.1.0"
         classpath "org.robolectric:robolectric-gradle-plugin:1.0.0-SNAPSHOT"
     }
 }

--- a/android-appcompat-v7/build.gradle
+++ b/android-appcompat-v7/build.gradle
@@ -4,8 +4,8 @@ buildscript {
             mavenCentral()
         }
 
-        classpath "com.android.tools.build:gradle:1.0.0"
-        classpath "com.github.jcandksolutions.gradle:android-unit-test:2.1.1"
+        classpath "com.android.tools.build:gradle:1.1.0"
+        classpath "org.robolectric:robolectric-gradle-plugin:1.0.0-SNAPSHOT"
     }
 }
 

--- a/android-appcompat-v7/build.gradle
+++ b/android-appcompat-v7/build.gradle
@@ -1,6 +1,8 @@
 buildscript {
     dependencies {
         repositories {
+            maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+            mavenLocal()
             mavenCentral()
         }
 
@@ -10,6 +12,7 @@ buildscript {
 }
 
 apply plugin: "com.android.application"
+apply plugin: "org.robolectric"
 
 android {
     compileSdkVersion 21
@@ -24,8 +27,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_7
     }
 }
-
-apply plugin: "android-unit-test"
 
 dependencies {
     compile "com.android.support:appcompat-v7:21.0.+"

--- a/android-appcompat-v7/src/main/test-project.properties
+++ b/android-appcompat-v7/src/main/test-project.properties
@@ -1,0 +1,1 @@
+android.library.reference.1=../../build/intermediates/exploded-aar/com.android.support/appcompat-v7/21.0.3

--- a/android-appcompat-v7/src/test/java/com/example/activity/MainActivityTest.java
+++ b/android-appcompat-v7/src/test/java/com/example/activity/MainActivityTest.java
@@ -12,7 +12,9 @@ import org.robolectric.RobolectricTestRunner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(RobolectricTestRunner.class)
+import com.example.activity.robolectric.Robo;
+
+@RunWith(Robo.class)
 public class MainActivityTest {
 
   @Test

--- a/android-appcompat-v7/src/test/java/com/example/activity/robolectric/Robo.java
+++ b/android-appcompat-v7/src/test/java/com/example/activity/robolectric/Robo.java
@@ -1,0 +1,51 @@
+package com.example.activity.robolectric;
+
+import android.app.Activity;
+
+import org.junit.runners.model.InitializationError;
+import org.robolectric.manifest.AndroidManifest;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.res.Fs;
+
+import java.io.File;
+
+public class Robo extends RobolectricTestRunner {
+
+    private static final int MAX_SDK_SUPPORTED_BY_ROBOLECTRIC = 18;
+    private static final int MIN_SDK_SUPPORTED_BY_MULTIDEX = 4;
+
+    // Paths to create Robolectric's App Manifest
+    private static final String MANIFEST_PATH = "src/main/AndroidManifest.xml";
+    private static final String RESOURCES_PATH = "src/main/res";
+    private static final String ASSETS_PATH = "src/main/assets";
+    private static final String PROJECT_NAME = "android-appcompat-v7";
+
+    // Required for appcompat-v7 Activities
+    private static final String ACTIVITY_THEME = "@style/RoboAppTheme";
+
+    public Robo(Class<?> testClass)
+            throws InitializationError {
+        super(testClass);
+    }
+
+    @Override
+    protected AndroidManifest getAppManifest(Config config) {
+
+        String manifestPath = MANIFEST_PATH;
+        String resourcesPath = RESOURCES_PATH;
+        String assetsPath = ASSETS_PATH;
+
+        if (!new File(manifestPath).exists()) {
+            manifestPath = PROJECT_NAME + "/" + MANIFEST_PATH;
+            resourcesPath = PROJECT_NAME + "/" + RESOURCES_PATH;
+            assetsPath = PROJECT_NAME + "/" + ASSETS_PATH;
+        }
+
+        return new AndroidManifest(
+            Fs.fileFromPath(manifestPath),
+            Fs.fileFromPath(resourcesPath),
+            Fs.fileFromPath(assetsPath));
+    }
+}
+

--- a/android-play-services/build.gradle
+++ b/android-play-services/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     dependencies {
         repositories {
+            maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
             mavenLocal()
             mavenCentral()
         }
@@ -11,7 +12,7 @@ buildscript {
 }
 
 apply plugin: "com.android.application"
-apply plugin: "robolectric"
+apply plugin: "org.robolectric"
 
 android {
     compileSdkVersion 21

--- a/android-play-services/build.gradle
+++ b/android-play-services/build.gradle
@@ -1,15 +1,17 @@
 buildscript {
     dependencies {
         repositories {
+            mavenLocal()
             mavenCentral()
         }
 
-        classpath "com.android.tools.build:gradle:1.0.0"
-        classpath "com.github.jcandksolutions.gradle:android-unit-test:2.1.1"
+        classpath "com.android.tools.build:gradle:1.1.0-rc1"
+        classpath "org.robolectric:robolectric-gradle-plugin:1.0.0-SNAPSHOT"
     }
 }
 
 apply plugin: "com.android.application"
+apply plugin: "robolectric"
 
 android {
     compileSdkVersion 21
@@ -24,8 +26,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_7
     }
 }
-
-apply plugin: "android-unit-test"
 
 dependencies {
     compile "com.google.android.gms:play-services:6.5.87"

--- a/android-play-services/build.gradle
+++ b/android-play-services/build.gradle
@@ -5,7 +5,7 @@ buildscript {
             mavenCentral()
         }
 
-        classpath "com.android.tools.build:gradle:1.1.0-rc1"
+        classpath "com.android.tools.build:gradle:1.1.0"
         classpath "org.robolectric:robolectric-gradle-plugin:1.0.0-SNAPSHOT"
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 include ':android-api-16'
 include ':android-api-19'
 include ':android-api-21'
-//include ':android-appcompat-v7'
+include ':android-appcompat-v7'
 include ':android-play-services'


### PR DESCRIPTION
The snapshot references to `org.robolectric:robolectric-gradle-plugin:1.0.0-SNAPSHOT` and `org.robolectric:robolectric:3.0-SNAPSHOT` were failing because the reference to [Sonatype snapshots](https://oss.sonatype.org/content/repositories/snapshots) was not being picked up during plugin dependency resolution. Also the plugin name seems to be `org.robolectric` and not just `robolectric`.

I also re-enabled & fixed the appcompat-v7 sample project, however I'm not sure if some of the workarounds I did should be performed in the robolectric library or plugin instead.